### PR TITLE
boards: use machine.Serial instead of machine.UART0

### DIFF
--- a/arduino-nano33/main.go
+++ b/arduino-nano33/main.go
@@ -44,8 +44,6 @@ var (
 	// used by i2c tests
 	accel    *mpu6050.Device
 	powerpin = machine.D7
-
-	serial = machine.UART0
 )
 
 const (
@@ -55,7 +53,7 @@ const (
 )
 
 func main() {
-	serial.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 	machine.I2C0.Configure(machine.I2CConfig{})
 	machine.InitADC()
 
@@ -80,8 +78,8 @@ func waitForStart() {
 	println("Press 't' key to begin running tests...")
 
 	for {
-		if serial.Buffered() > 0 {
-			data, _ := serial.ReadByte()
+		if machine.Serial.Buffered() > 0 {
+			data, _ := machine.Serial.ReadByte()
 
 			if data != 't' {
 				time.Sleep(100 * time.Millisecond)

--- a/arduino/main.go
+++ b/arduino/main.go
@@ -43,8 +43,6 @@ var (
 
 	// used by i2c tests
 	accel *mpu6050.Device
-
-	serial = machine.UART0
 )
 
 const (
@@ -53,7 +51,7 @@ const (
 )
 
 func main() {
-	serial.Configure(machine.UARTConfig{BaudRate: 57600})
+	machine.Serial.Configure(machine.UARTConfig{BaudRate: 57600})
 	machine.I2C0.Configure(machine.I2CConfig{})
 	machine.InitADC()
 
@@ -77,8 +75,8 @@ func waitForStart() {
 	println("Press 't' key to begin running tests...")
 
 	for {
-		if serial.Buffered() > 0 {
-			data, _ := serial.ReadByte()
+		if machine.Serial.Buffered() > 0 {
+			data, _ := machine.Serial.ReadByte()
 
 			if data != 't' {
 				time.Sleep(100 * time.Millisecond)

--- a/circuitplay-express/main.go
+++ b/circuitplay-express/main.go
@@ -40,8 +40,6 @@ var (
 
 	// used by i2c tests
 	accel *lis3dh.Device
-
-	serial = machine.UART0
 )
 
 const (
@@ -50,7 +48,7 @@ const (
 )
 
 func main() {
-	serial.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 	machine.I2C1.Configure(machine.I2CConfig{SCL: machine.SCL1_PIN, SDA: machine.SDA1_PIN})
 	machine.InitADC()
 
@@ -75,8 +73,8 @@ func waitForStart() {
 	println("Press 't' key to begin running tests...")
 
 	for {
-		if serial.Buffered() > 0 {
-			data, _ := serial.ReadByte()
+		if machine.Serial.Buffered() > 0 {
+			data, _ := machine.Serial.ReadByte()
 
 			if data != 't' {
 				time.Sleep(200 * time.Millisecond)

--- a/hifive1b/main.go
+++ b/hifive1b/main.go
@@ -33,12 +33,10 @@ var (
 	// used by i2c tests
 	accel    *mpu6050.Device
 	powerpin = machine.D9
-
-	serial = machine.UART0
 )
 
 func main() {
-	serial.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 	machine.I2C0.Configure(machine.I2CConfig{})
 
 	waitForStart()
@@ -59,8 +57,8 @@ func waitForStart() {
 	println("Press 't' key to begin running tests...")
 
 	for {
-		if serial.Buffered() > 0 {
-			data, _ := serial.ReadByte()
+		if machine.Serial.Buffered() > 0 {
+			data, _ := machine.Serial.ReadByte()
 
 			if data != 't' {
 				time.Sleep(100 * time.Millisecond)

--- a/itsybitsy-m4/main.go
+++ b/itsybitsy-m4/main.go
@@ -43,8 +43,6 @@ var (
 
 	// used by i2c tests
 	powerpin = machine.D7
-
-	serial = machine.UART0
 )
 
 const (
@@ -53,7 +51,7 @@ const (
 )
 
 func main() {
-	serial.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 	machine.I2C0.Configure(machine.I2CConfig{})
 	machine.InitADC()
 
@@ -78,8 +76,8 @@ func waitForStart() {
 	println("Press 't' key to begin running tests...")
 
 	for {
-		if serial.Buffered() > 0 {
-			data, _ := serial.ReadByte()
+		if machine.Serial.Buffered() > 0 {
+			data, _ := machine.Serial.ReadByte()
 
 			if data != 't' {
 				time.Sleep(100 * time.Millisecond)

--- a/itsybitsy-nrf52840/main.go
+++ b/itsybitsy-nrf52840/main.go
@@ -44,8 +44,6 @@ var (
 	// used by i2c tests
 	accel    *mpu6050.Device
 	powerpin = machine.D7
-
-	serial = machine.UART0
 )
 
 const (
@@ -54,7 +52,7 @@ const (
 )
 
 func main() {
-	serial.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 	machine.I2C0.Configure(machine.I2CConfig{})
 	machine.InitADC()
 
@@ -79,8 +77,8 @@ func waitForStart() {
 	println("Press 't' key to begin running tests...")
 
 	for {
-		if serial.Buffered() > 0 {
-			data, _ := serial.ReadByte()
+		if machine.Serial.Buffered() > 0 {
+			data, _ := machine.Serial.ReadByte()
 
 			if data != 't' {
 				time.Sleep(100 * time.Millisecond)

--- a/maixbit/main.go
+++ b/maixbit/main.go
@@ -44,12 +44,10 @@ var (
 	// used by i2c tests
 	accel    *mpu6050.Device
 	powerpin = machine.D33
-
-	serial = machine.UART0
 )
 
 func main() {
-	serial.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 	machine.I2C0.Configure(machine.I2CConfig{})
 
 	waitForStart()
@@ -73,8 +71,8 @@ func waitForStart() {
 	println("Press 't' key to begin running tests...")
 
 	for {
-		if serial.Buffered() > 0 {
-			data, _ := serial.ReadByte()
+		if machine.Serial.Buffered() > 0 {
+			data, _ := machine.Serial.ReadByte()
 
 			if data != 't' {
 				time.Sleep(100 * time.Millisecond)

--- a/microbit/main.go
+++ b/microbit/main.go
@@ -29,12 +29,10 @@ var (
 
 	// used by i2c tests
 	mag *mag3110.Device
-
-	serial = machine.UART0
 )
 
 func main() {
-	serial.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 	machine.I2C0.Configure(machine.I2CConfig{})
 
 	waitForStart()
@@ -55,8 +53,8 @@ func waitForStart() {
 	println("Press 't' key to begin running tests...")
 
 	for {
-		if serial.Buffered() > 0 {
-			data, _ := serial.ReadByte()
+		if machine.Serial.Buffered() > 0 {
+			data, _ := machine.Serial.ReadByte()
 
 			if data != 't' {
 				time.Sleep(100 * time.Millisecond)

--- a/stm32f4disco-1/main.go
+++ b/stm32f4disco-1/main.go
@@ -33,8 +33,6 @@ var (
 
 	// used by i2c tests
 	accel *mpu6050.Device
-
-	serial = machine.UART0
 )
 
 func main() {
@@ -58,8 +56,8 @@ func waitForStart() {
 	println("Press 't' key to begin running tests...")
 
 	for {
-		if serial.Buffered() > 0 {
-			data, _ := serial.ReadByte()
+		if machine.Serial.Buffered() > 0 {
+			data, _ := machine.Serial.ReadByte()
 
 			if data != 't' {
 				time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
See: https://github.com/tinygo-org/tinygo/pull/1880

Untested, I'm not sure how to run the tests:

```
$ make all
rm -rf build
mkdir -p build
go build -o build/testrunner tools/testrunner/*
tinygo flash -size short -target=itsybitsy-m4 -port=/dev/itsybitsy_m4 ./itsybitsy-m4/
main module (tinygo.org/x/tinyhci) does not contain package tinygo.org/x/tinyhci/itsybitsy-m4
make: *** [Makefile:16: test-itsybitsy-m4] Error 1
```