### PR TITLE
itsybitsy-m4: add spi test

### DIFF
--- a/itsybitsy-m4/main.go
+++ b/itsybitsy-m4/main.go
@@ -20,6 +20,8 @@ package main
 // 	ItsyBitsy-M4 G <--> MPU-6050 GND
 // 	ItsyBitsy-M4 D7 <--> MPU-6050 VCC
 //
+// SPI tests:
+// 	ItsyBitsy-M4 MOSI <--> ItsyBitsy-M4 MISO
 import (
 	"machine"
 	"strconv"
@@ -64,6 +66,7 @@ func main() {
 	analogReadGround()
 	analogReadHalfVoltage()
 	i2cConnection()
+	spiTxRx()
 
 	endTests()
 }
@@ -274,6 +277,40 @@ func i2cConnection() {
 		return
 	}
 
+	printtestresult("pass")
+}
+
+// checks if it is possible to send/receive by spi
+func spiTxRx() {
+	spi0 := machine.SPI0
+	spi0.Configure(machine.SPIConfig{
+		SCK:       machine.SPI0_SCK_PIN,
+		SDO:       machine.SPI0_SDO_PIN,
+		SDI:       machine.SPI0_SDI_PIN,
+		Frequency: 4000000,
+	})
+
+	from := make([]byte, 8)
+	for i := range from {
+		from[i] = byte(i)
+	}
+	to := make([]byte, len(from))
+
+	printtest("spiTx")
+	err := spi0.Tx(from, to)
+	if err != nil {
+		printtestresult("fail")
+	} else {
+		printtestresult("pass")
+	}
+
+	printtest("spiRx")
+	for i := range from {
+		if from[i] != to[i] {
+			printtestresult("fail")
+			return
+		}
+	}
 	printtestresult("pass")
 }
 


### PR DESCRIPTION
This PR adds the SPI test.
I am first adding it to itsybitsy-m4 only, but if it looks OK, other targets can be added with the same code.

