### PR TITLE
boards: configure i2c bus again after turning on power to MPU-6050 during tests

### DIFF
--- a/arduino-nano33/go.mod
+++ b/arduino-nano33/go.mod
@@ -2,4 +2,4 @@ module arduino-nano33
 
 go 1.17
 
-require tinygo.org/x/drivers v0.23.0
+require tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854

--- a/arduino-nano33/go.sum
+++ b/arduino-nano33/go.sum
@@ -20,8 +20,8 @@ tinygo.org/x/drivers v0.14.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2
 tinygo.org/x/drivers v0.15.1/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.19.0/go.mod h1:uJD/l1qWzxzLx+vcxaW0eY464N5RAgFi1zTVzASFdqI=
-tinygo.org/x/drivers v0.23.0 h1:fUy4OmLOWWYCOzDp/83Qewej1Q+YgUpwkm11e7gxUc0=
-tinygo.org/x/drivers v0.23.0/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
+tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854 h1:Fwjl/wDKzuc8iNat+v69CDQ3s0RKP+h1f/CpDbP9IrY=
+tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
 tinygo.org/x/tinyfont v0.2.1/go.mod h1:eLqnYSrFRjt5STxWaMeOWJTzrKhXqpWw7nU3bPfKOAM=
 tinygo.org/x/tinyfont v0.3.0/go.mod h1:+TV5q0KpwSGRWnN+ITijsIhrWYJkoUCp9MYELjKpAXk=
 tinygo.org/x/tinyfs v0.1.0/go.mod h1:ysc8Y92iHfhTXeyEM9+c7zviUQ4fN9UCFgSOFfMWv20=

--- a/arduino-nano33/main.go
+++ b/arduino-nano33/main.go
@@ -273,7 +273,13 @@ func i2cConnection() {
 	powerpin.High()
 	time.Sleep(200 * time.Millisecond)
 
-	accel.Configure()
+	machine.I2C0.Configure(machine.I2CConfig{})
+
+	err := accel.Configure()
+	if err != nil {
+	    printtestresult(err.Error())
+	    return
+	}
 	time.Sleep(500 * time.Millisecond)
 
 	if !accel.Connected() {

--- a/hifive1b/go.mod
+++ b/hifive1b/go.mod
@@ -2,4 +2,4 @@ module hifive1b
 
 go 1.17
 
-require tinygo.org/x/drivers v0.23.0
+require tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854

--- a/hifive1b/go.sum
+++ b/hifive1b/go.sum
@@ -20,8 +20,8 @@ tinygo.org/x/drivers v0.14.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2
 tinygo.org/x/drivers v0.15.1/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.19.0/go.mod h1:uJD/l1qWzxzLx+vcxaW0eY464N5RAgFi1zTVzASFdqI=
-tinygo.org/x/drivers v0.23.0 h1:fUy4OmLOWWYCOzDp/83Qewej1Q+YgUpwkm11e7gxUc0=
-tinygo.org/x/drivers v0.23.0/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
+tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854 h1:Fwjl/wDKzuc8iNat+v69CDQ3s0RKP+h1f/CpDbP9IrY=
+tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
 tinygo.org/x/tinyfont v0.2.1/go.mod h1:eLqnYSrFRjt5STxWaMeOWJTzrKhXqpWw7nU3bPfKOAM=
 tinygo.org/x/tinyfont v0.3.0/go.mod h1:+TV5q0KpwSGRWnN+ITijsIhrWYJkoUCp9MYELjKpAXk=
 tinygo.org/x/tinyfs v0.1.0/go.mod h1:ysc8Y92iHfhTXeyEM9+c7zviUQ4fN9UCFgSOFfMWv20=

--- a/hifive1b/main.go
+++ b/hifive1b/main.go
@@ -172,7 +172,13 @@ func i2cConnection() {
 	powerpin.High()
 	time.Sleep(500 * time.Millisecond)
 
-	accel.Configure()
+	machine.I2C0.Configure(machine.I2CConfig{})
+
+	err := accel.Configure()
+	if err != nil {
+	    printtestresult(err.Error())
+	    return
+	}
 	time.Sleep(400 * time.Millisecond)
 
 	if !accel.Connected() {

--- a/itsybitsy-m4/go.mod
+++ b/itsybitsy-m4/go.mod
@@ -2,4 +2,4 @@ module itsybitsy-m4
 
 go 1.17
 
-require tinygo.org/x/drivers v0.23.0
+require tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854

--- a/itsybitsy-m4/go.sum
+++ b/itsybitsy-m4/go.sum
@@ -20,8 +20,8 @@ tinygo.org/x/drivers v0.14.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2
 tinygo.org/x/drivers v0.15.1/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.19.0/go.mod h1:uJD/l1qWzxzLx+vcxaW0eY464N5RAgFi1zTVzASFdqI=
-tinygo.org/x/drivers v0.23.0 h1:fUy4OmLOWWYCOzDp/83Qewej1Q+YgUpwkm11e7gxUc0=
-tinygo.org/x/drivers v0.23.0/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
+tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854 h1:Fwjl/wDKzuc8iNat+v69CDQ3s0RKP+h1f/CpDbP9IrY=
+tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
 tinygo.org/x/tinyfont v0.2.1/go.mod h1:eLqnYSrFRjt5STxWaMeOWJTzrKhXqpWw7nU3bPfKOAM=
 tinygo.org/x/tinyfont v0.3.0/go.mod h1:+TV5q0KpwSGRWnN+ITijsIhrWYJkoUCp9MYELjKpAXk=
 tinygo.org/x/tinyfs v0.1.0/go.mod h1:ysc8Y92iHfhTXeyEM9+c7zviUQ4fN9UCFgSOFfMWv20=

--- a/itsybitsy-m4/main.go
+++ b/itsybitsy-m4/main.go
@@ -268,8 +268,13 @@ func i2cConnection() {
 	// turn on power and should be connected now
 	powerpin.High()
 	time.Sleep(100 * time.Millisecond)
+	machine.I2C0.Configure(machine.I2CConfig{})
 
-	accel.Configure()
+	err := accel.Configure()
+	if err != nil {
+	    printtestresult(err.Error())
+	    return
+	}
 	time.Sleep(100 * time.Millisecond)
 
 	if !accel.Connected() {

--- a/itsybitsy-nrf52840/go.mod
+++ b/itsybitsy-nrf52840/go.mod
@@ -2,4 +2,4 @@ module itsybitsy-nrf52840
 
 go 1.17
 
-require tinygo.org/x/drivers v0.23.0
+require tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854

--- a/itsybitsy-nrf52840/go.sum
+++ b/itsybitsy-nrf52840/go.sum
@@ -20,8 +20,8 @@ tinygo.org/x/drivers v0.14.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2
 tinygo.org/x/drivers v0.15.1/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.19.0/go.mod h1:uJD/l1qWzxzLx+vcxaW0eY464N5RAgFi1zTVzASFdqI=
-tinygo.org/x/drivers v0.23.0 h1:fUy4OmLOWWYCOzDp/83Qewej1Q+YgUpwkm11e7gxUc0=
-tinygo.org/x/drivers v0.23.0/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
+tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854 h1:Fwjl/wDKzuc8iNat+v69CDQ3s0RKP+h1f/CpDbP9IrY=
+tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
 tinygo.org/x/tinyfont v0.2.1/go.mod h1:eLqnYSrFRjt5STxWaMeOWJTzrKhXqpWw7nU3bPfKOAM=
 tinygo.org/x/tinyfont v0.3.0/go.mod h1:+TV5q0KpwSGRWnN+ITijsIhrWYJkoUCp9MYELjKpAXk=
 tinygo.org/x/tinyfs v0.1.0/go.mod h1:ysc8Y92iHfhTXeyEM9+c7zviUQ4fN9UCFgSOFfMWv20=

--- a/itsybitsy-nrf52840/main.go
+++ b/itsybitsy-nrf52840/main.go
@@ -257,7 +257,13 @@ func i2cConnection() {
 	powerpin.High()
 	time.Sleep(200 * time.Millisecond)
 
-	accel.Configure()
+	machine.I2C0.Configure(machine.I2CConfig{})
+
+	err := accel.Configure()
+	if err != nil {
+	    printtestresult(err.Error())
+	    return
+	}
 	time.Sleep(500 * time.Millisecond)
 
 	if !accel.Connected() {

--- a/maixbit/go.mod
+++ b/maixbit/go.mod
@@ -2,4 +2,4 @@ module maixbit
 
 go 1.17
 
-require tinygo.org/x/drivers v0.23.0
+require tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854

--- a/maixbit/go.sum
+++ b/maixbit/go.sum
@@ -20,8 +20,8 @@ tinygo.org/x/drivers v0.14.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2
 tinygo.org/x/drivers v0.15.1/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.19.0/go.mod h1:uJD/l1qWzxzLx+vcxaW0eY464N5RAgFi1zTVzASFdqI=
-tinygo.org/x/drivers v0.23.0 h1:fUy4OmLOWWYCOzDp/83Qewej1Q+YgUpwkm11e7gxUc0=
-tinygo.org/x/drivers v0.23.0/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
+tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854 h1:Fwjl/wDKzuc8iNat+v69CDQ3s0RKP+h1f/CpDbP9IrY=
+tinygo.org/x/drivers v0.23.1-0.20221018183233-42dc6eb06854/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
 tinygo.org/x/tinyfont v0.2.1/go.mod h1:eLqnYSrFRjt5STxWaMeOWJTzrKhXqpWw7nU3bPfKOAM=
 tinygo.org/x/tinyfont v0.3.0/go.mod h1:+TV5q0KpwSGRWnN+ITijsIhrWYJkoUCp9MYELjKpAXk=
 tinygo.org/x/tinyfs v0.1.0/go.mod h1:ysc8Y92iHfhTXeyEM9+c7zviUQ4fN9UCFgSOFfMWv20=

--- a/maixbit/main.go
+++ b/maixbit/main.go
@@ -241,7 +241,13 @@ func i2cConnection() {
 	powerpin.High()
 	time.Sleep(500 * time.Millisecond)
 
-	accel.Configure()
+	machine.I2C0.Configure(machine.I2CConfig{})
+
+	err := accel.Configure()
+	if err != nil {
+	    printtestresult(err.Error())
+	    return
+	}
 	time.Sleep(400 * time.Millisecond)
 
 	if !accel.Connected() {


### PR DESCRIPTION
This PR updates the test programs to configure the i2c bus again after turning on power to MPU-6050 during tests for the boards that support that. It also updates those same boards to use the latest `dev` branch of the drivers repo.