### PR TITLE
microbit: add ADC tests, requiring changing a few pins around

### DIFF
--- a/microbit/go.mod
+++ b/microbit/go.mod
@@ -2,4 +2,4 @@ module microbit
 
 go 1.17
 
-require tinygo.org/x/drivers v0.23.0
+require tinygo.org/x/drivers v0.23.1-0.20221123211343-a888570c8caf

--- a/microbit/go.sum
+++ b/microbit/go.sum
@@ -20,8 +20,8 @@ tinygo.org/x/drivers v0.14.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2
 tinygo.org/x/drivers v0.15.1/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.19.0/go.mod h1:uJD/l1qWzxzLx+vcxaW0eY464N5RAgFi1zTVzASFdqI=
-tinygo.org/x/drivers v0.23.0 h1:fUy4OmLOWWYCOzDp/83Qewej1Q+YgUpwkm11e7gxUc0=
-tinygo.org/x/drivers v0.23.0/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
+tinygo.org/x/drivers v0.23.1-0.20221123211343-a888570c8caf h1:ILxaqlqj5AvhFLA7hKx/Usdtx/iHdDzNPaMw0ECoEoI=
+tinygo.org/x/drivers v0.23.1-0.20221123211343-a888570c8caf/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
 tinygo.org/x/tinyfont v0.2.1/go.mod h1:eLqnYSrFRjt5STxWaMeOWJTzrKhXqpWw7nU3bPfKOAM=
 tinygo.org/x/tinyfont v0.3.0/go.mod h1:+TV5q0KpwSGRWnN+ITijsIhrWYJkoUCp9MYELjKpAXk=
 tinygo.org/x/tinyfs v0.1.0/go.mod h1:ysc8Y92iHfhTXeyEM9+c7zviUQ4fN9UCFgSOFfMWv20=


### PR DESCRIPTION
This PR adds ADC tests to the Microbit to support testing of https://github.com/tinygo-org/tinygo/pull/3315