### PR TITLE
lib: add initial work on TAP library implementation

### DIFF
--- a/lib/tap/tap.go
+++ b/lib/tap/tap.go
@@ -1,0 +1,92 @@
+// package tap provides a simple TAP (Test Anything Protocol) implementation for Go.
+// It is designed to be used in test code, and provides methods to generate
+// TAP output indicating test results.
+package tap
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Tester is a type to encapsulate test state.  Methods on this type generate TAP
+// output.
+type Tester struct {
+	nextTestNumber int
+
+	// TODO toggles the TODO directive for Ok, Fail, Pass, and similar.
+	TODO bool
+
+	print func(messages ...any)
+}
+
+func New() *Tester {
+	return &Tester{
+		nextTestNumber: 1,
+		print:          printer,
+	}
+}
+
+// Header displays a TAP header including version number and expected
+// number of tests to run.
+func (t *Tester) Header(testCount int) {
+	t.print("TAP version 13")
+	if testCount > 0 {
+		t.print("1.." + strconv.Itoa(testCount))
+	}
+}
+
+// Ok generates TAP output indicating whether a test passed or failed.
+func (t *Tester) Ok(test bool, description string) {
+	// did the test pass or not?
+	ok := "ok"
+	if !test {
+		ok = "not ok"
+	}
+
+	if t.TODO {
+		t.print(ok, t.nextTestNumber, "# TODO", description)
+	} else {
+		t.print(ok, t.nextTestNumber, "-", description)
+	}
+	t.nextTestNumber++
+}
+
+// Fail indicates that a test has failed.  This is typically only used when the
+// logic is too complex to fit naturally into an Ok() call.
+func (t *Tester) Fail(description string) {
+	t.Ok(false, description)
+}
+
+// Pass indicates that a test has passed.  This is typically only used when the
+// logic is too complex to fit naturally into an Ok() call.
+func (t *Tester) Pass(description string) {
+	t.Ok(true, description)
+}
+
+// Skip indicates that a test has been skipped.
+func (t *Tester) Skip(count int, description string) {
+	for i := 0; i < count; i++ {
+		t.print("ok", t.nextTestNumber, "# SKIP", description)
+		t.nextTestNumber++
+	}
+}
+
+// Diagnostic generates a diagnostic from the message,
+// which may span multiple lines.
+func (t *Tester) Diagnostic(message string) {
+	t.print("#", escapeNewlines(message))
+}
+
+func printer(messages ...any) {
+	for i, m := range messages {
+		if i > 0 {
+			print(" ")
+		}
+		print(m)
+	}
+	print("\n")
+}
+
+func escapeNewlines(s string) string {
+	return strings.Replace(strings.TrimRight(s, "\n"), "\n", "\n# ", -1)
+}

--- a/lib/tap/tap_test.go
+++ b/lib/tap/tap_test.go
@@ -1,0 +1,114 @@
+package tap
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// helper to create a tester with output captured in a buffer
+func newTestTAP() (*Tester, *bytes.Buffer) {
+	var buf bytes.Buffer
+	tap := &Tester{
+		nextTestNumber: 1,
+		print: func(messages ...any) {
+			for i, m := range messages {
+				if i > 0 {
+					fmt.Fprint(&buf, " ")
+				}
+				fmt.Fprint(&buf, m)
+			}
+			fmt.Fprint(&buf, "\n")
+		},
+	}
+	return tap, &buf
+}
+
+func TestHeader(t *testing.T) {
+	tap, buf := newTestTAP()
+	tap.Header(3)
+	expected := "TAP version 13\n1..3\n"
+	if buf.String() != expected {
+		t.Errorf("Header() output = %q, want %q", buf.String(), expected)
+	}
+}
+
+func TestOk(t *testing.T) {
+	tap, buf := newTestTAP()
+	tap.Ok(true, "should pass")
+	expected := "ok 1 - should pass\n"
+	if buf.String() != expected {
+		t.Errorf("Ok(true) output = %q, want %q", buf.String(), expected)
+	}
+}
+
+func TestNotOk(t *testing.T) {
+	tap, buf := newTestTAP()
+	tap.Ok(false, "should fail")
+	expected := "not ok 1 - should fail\n"
+	if buf.String() != expected {
+		t.Errorf("Ok(false) output = %q, want %q", buf.String(), expected)
+	}
+}
+
+func TestOkTODO(t *testing.T) {
+	tap, buf := newTestTAP()
+	tap.TODO = true
+	tap.Ok(true, "pending feature")
+	expected := "ok 1 # TODO pending feature\n"
+	if buf.String() != expected {
+		t.Errorf("Ok(true) with TODO output = %q, want %q", buf.String(), expected)
+	}
+}
+
+func TestFailAndPass(t *testing.T) {
+	tap, buf := newTestTAP()
+	tap.Fail("fail desc")
+	tap.Pass("pass desc")
+	expected := "not ok 1 - fail desc\nok 2 - pass desc\n"
+	if buf.String() != expected {
+		t.Errorf("Fail/Pass output = %q, want %q", buf.String(), expected)
+	}
+}
+
+func TestSkip(t *testing.T) {
+	tap, buf := newTestTAP()
+	tap.Skip(2, "not implemented")
+	expected := "ok 1 # SKIP not implemented\nok 2 # SKIP not implemented\n"
+	if buf.String() != expected {
+		t.Errorf("Skip output = %q, want %q", buf.String(), expected)
+	}
+}
+
+func TestDiagnosticSingleLine(t *testing.T) {
+	tap, buf := newTestTAP()
+	tap.Diagnostic("this is a comment")
+	expected := "# this is a comment\n"
+	if buf.String() != expected {
+		t.Errorf("Diagnostic output = %q, want %q", buf.String(), expected)
+	}
+}
+
+func TestDiagnosticMultiLine(t *testing.T) {
+	tap, buf := newTestTAP()
+	tap.Diagnostic("line 1\nline 2\nline 3")
+	expected := "# line 1\n# line 2\n# line 3\n"
+	if buf.String() != expected {
+		t.Errorf("Diagnostic multiline output = %q, want %q", buf.String(), expected)
+	}
+}
+
+func TestNextTestNumberIncrements(t *testing.T) {
+	tap, buf := newTestTAP()
+	tap.Ok(true, "first")
+	tap.Ok(true, "second")
+	tap.Ok(false, "third")
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("Expected 3 lines, got %d", len(lines))
+	}
+	if !strings.HasPrefix(lines[0], "ok 1") || !strings.HasPrefix(lines[1], "ok 2") || !strings.HasPrefix(lines[2], "not ok 3") {
+		t.Errorf("Test numbers did not increment as expected: %v", lines)
+	}
+}


### PR DESCRIPTION
This PR is to add initial work on a TAP library implementation.

https://testanything.org/

I would like to replace the current test protocol used with boards to one based on TAP :test_tube: 