### PR TITLE
Use espflash

### DIFF
--- a/itsybitsy-nrf52840/main.go
+++ b/itsybitsy-nrf52840/main.go
@@ -70,8 +70,8 @@ func main() {
 	t.Ok(analogReadVoltage(), "analogReadVoltage (ADC)")
 	t.Ok(analogReadGround(), "analogReadGround (ADC)")
 	t.Ok(analogReadHalfVoltage(), "analogReadHalfVoltage (ADC)")
-	t.Ok(i2cConnection(), "i2cConnection")
-	t.Ok(spiTxRx(), "spiTxRx")
+	t.Ok(i2cConnection(), "i2cConnection (MPU6050)")
+	t.Ok(spiTxRx(), "spiTxRx (SPI)")
 
 	endTests()
 }

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,8 +13,6 @@ RUN git clone https://github.com/shumatech/BOSSA.git && \
 
 RUN pip3 install git+https://github.com/kendryte/kflash.py.git --break-system-packages
 
-RUN pip3 install esptool --break-system-packages
-
 ENV GO_RELEASE=1.25.7
 RUN wget https://dl.google.com/go/go${GO_RELEASE}.linux-amd64.tar.gz && \
     tar xfv go${GO_RELEASE}.linux-amd64.tar.gz -C /usr/local && \


### PR DESCRIPTION
Small cleanups to no longer install esptool since not needed for flashing esp32 boards.