### PR TITLE
server: download tinygo binary directly as tar.gz instead of unzipping

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -23,7 +23,8 @@ FROM tinygohci-base AS tinygohci-build
 ENV TINYGO_RELEASE=0.39.0
 ARG TINYGO_DOWNLOAD_SHA=1234
 
-ADD tools/docker/versions/${TINYGO_DOWNLOAD_SHA}.tar.gz /usr/local
+COPY tools/docker/versions/${TINYGO_DOWNLOAD_SHA}.deb /tmp/tinygo.deb
+RUN dpkg -i /tmp/tinygo.deb && rm /tmp/tinygo.deb
 ENV PATH=${PATH}:/usr/local/tinygo/bin
 
 RUN apt-get remove -y wget && \

--- a/tools/server/main.go
+++ b/tools/server/main.go
@@ -275,7 +275,7 @@ func buildDocker(sha string) error {
 // with this SHA.
 func downloadBinary(url, sha string) error {
 	// check if the file is already downloaded for this sha
-	dest := "tools/docker/versions/" + sha + ".tar.gz"
+	dest := "tools/docker/versions/" + sha + ".deb"
 	if !fileExists(dest) {
 		log.Println("Downloading binary for", sha)
 

--- a/tools/server/main.go
+++ b/tools/server/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"time"
 
@@ -276,38 +275,15 @@ func buildDocker(sha string) error {
 // with this SHA.
 func downloadBinary(url, sha string) error {
 	// check if the file is already downloaded for this sha
-	if !fileExists("tools/docker/versions/" + sha + ".tar.gz") {
+	dest := "tools/docker/versions/" + sha + ".tar.gz"
+	if !fileExists(dest) {
 		log.Println("Downloading binary for", sha)
 
-		resp, err := grab.Get("tinygo-latest.zip", url)
+		resp, err := grab.Get(dest, url)
 		if err != nil {
 			return err
 		}
 		log.Println("downloaded bytes:", resp.BytesComplete())
-		// unzip
-		log.Println("unzipping")
-		out, err := exec.Command("unzip", "tinygo-latest.zip",
-			"tinygo*.linux-amd64.tar.gz").CombinedOutput()
-		if err != nil {
-			return err
-		}
-		log.Println(string(out))
-
-		// move file
-		log.Println("moving file")
-		f, err := filepath.Glob("tinygo*.linux-amd64.tar.gz")
-		if err != nil {
-			return err
-		}
-		err = os.Rename(f[0], "tools/docker/versions/"+sha+".tar.gz")
-		if err != nil {
-			return err
-		}
-
-		err = os.Remove("tinygo-latest.zip")
-		if err != nil {
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR is download tinygo binary directly as tar.gz instead of unzipping, for https://github.com/tinygo-org/tinygo/pull/5310